### PR TITLE
Adds Where clause to struct definition.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,9 @@ use std::raw::Repr;
 use fixed_size_array::FixedSizeArray;
 
 /// An iterator constructed by the `literator!` macro.
-pub struct Literator<Array, Elem> {
+pub struct Literator<Array, Elem>
+    where Array: FixedSizeArray<Elem=Elem>
+{
     pos: isize,
     array: Option<Array>,
     phantom: PhantomData<[Elem; 17]>,


### PR DESCRIPTION
This was preventing me from compiling under Rust 1.0.0 beta, I believe.
